### PR TITLE
feat：添加统计 API 和仪表盘统计类型

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -11,3 +11,5 @@ EMBEDDING_TYPE=openai
 EMBEDDING_API_URL=
 EMBEDDING_API_KEY=
 EMBEDDING_MODEL=text-embedding-3-small                                                                  
+# 管理端-客服
+ADMIN_PASSWORD=admin

--- a/backend/controller/quick_reply_controller.go
+++ b/backend/controller/quick_reply_controller.go
@@ -1,0 +1,216 @@
+package controller
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/2930134478/AI-CS/backend/service"
+	"github.com/gin-gonic/gin"
+)
+
+// QuickReplyController 负责处理快捷回复模板相关的 HTTP 请求。
+type QuickReplyController struct {
+	service *service.QuickReplyService
+}
+
+// NewQuickReplyController 创建 QuickReplyController 实例。
+func NewQuickReplyController(service *service.QuickReplyService) *QuickReplyController {
+	return &QuickReplyController{service: service}
+}
+
+// ListQuickReplies 获取快捷回复模板列表。
+// GET /quick-replies?user_id=1&category=问候
+func (c *QuickReplyController) ListQuickReplies(ctx *gin.Context) {
+	// 获取用户ID
+	userIDStr := ctx.Query("user_id")
+	if userIDStr == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id 参数必填"})
+		return
+	}
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id 参数不合法"})
+		return
+	}
+
+	// 获取分类（可选）
+	category := ctx.Query("category")
+
+	// 查询模板列表
+	summaries, err := c.service.ListQuickReplies(uint(userID), category)
+	if err != nil {
+		log.Printf("查询快捷回复模板列表失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "查询失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"quick_replies": summaries,
+	})
+}
+
+// GetQuickReply 获取快捷回复模板详情。
+// GET /quick-replies/:id
+func (c *QuickReplyController) GetQuickReply(ctx *gin.Context) {
+	idStr := ctx.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "ID 不合法"})
+		return
+	}
+
+	summary, err := c.service.GetQuickReply(uint(id))
+	if err != nil {
+		log.Printf("查询快捷回复模板失败: %v", err)
+		ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, summary)
+}
+
+// CreateQuickReply 创建快捷回复模板。
+// POST /quick-replies
+func (c *QuickReplyController) CreateQuickReply(ctx *gin.Context) {
+	var req struct {
+		UserID    *uint   `json:"user_id"`
+		Title     string  `json:"title"`
+		Content   string  `json:"content" binding:"required"`
+		Category  string  `json:"category"`
+		SortOrder int     `json:"sort_order"`
+	}
+
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	summary, err := c.service.CreateQuickReply(service.CreateQuickReplyInput{
+		UserID:    req.UserID,
+		Title:     req.Title,
+		Content:   req.Content,
+		Category:  req.Category,
+		SortOrder: req.SortOrder,
+	})
+	if err != nil {
+		log.Printf("创建快捷回复模板失败: %v", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, summary)
+}
+
+// UpdateQuickReply 更新快捷回复模板。
+// PUT /quick-replies/:id
+func (c *QuickReplyController) UpdateQuickReply(ctx *gin.Context) {
+	idStr := ctx.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "ID 不合法"})
+		return
+	}
+
+	var req struct {
+		Title     *string `json:"title"`
+		Content   *string `json:"content"`
+		Category  *string `json:"category"`
+		SortOrder *int    `json:"sort_order"`
+		UserID    *uint   `json:"user_id"` // 操作者ID，用于权限检查
+	}
+
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	summary, err := c.service.UpdateQuickReply(uint(id), service.UpdateQuickReplyInput{
+		Title:     req.Title,
+		Content:   req.Content,
+		Category:  req.Category,
+		SortOrder: req.SortOrder,
+	}, req.UserID)
+	if err != nil {
+		log.Printf("更新快捷回复模板失败: %v", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, summary)
+}
+
+// DeleteQuickReply 删除快捷回复模板。
+// DELETE /quick-replies/:id
+func (c *QuickReplyController) DeleteQuickReply(ctx *gin.Context) {
+	idStr := ctx.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "ID 不合法"})
+		return
+	}
+
+	// 获取操作者ID
+	userIDStr := ctx.Query("user_id")
+	var userID *uint
+	if userIDStr != "" {
+		uid, err := strconv.ParseUint(userIDStr, 10, 64)
+		if err == nil {
+			u := uint(uid)
+			userID = &u
+		}
+	}
+
+	if err := c.service.DeleteQuickReply(uint(id), userID); err != nil {
+		log.Printf("删除快捷回复模板失败: %v", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+}
+
+// RecordUsage 记录快捷回复使用。
+// POST /quick-replies/:id/use
+func (c *QuickReplyController) RecordUsage(ctx *gin.Context) {
+	idStr := ctx.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "ID 不合法"})
+		return
+	}
+
+	if err := c.service.RecordUsage(uint(id)); err != nil {
+		log.Printf("记录使用次数失败: %v", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "记录成功"})
+}
+
+// GetCategories 获取所有分类。
+// GET /quick-replies/categories?user_id=1
+func (c *QuickReplyController) GetCategories(ctx *gin.Context) {
+	userIDStr := ctx.Query("user_id")
+	if userIDStr == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id 参数必填"})
+		return
+	}
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id 参数不合法"})
+		return
+	}
+
+	categories, err := c.service.GetCategories(uint(userID))
+	if err != nil {
+		log.Printf("获取分类列表失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"categories": categories,
+	})
+}

--- a/backend/controller/statistics_controller.go
+++ b/backend/controller/statistics_controller.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/2930134478/AI-CS/backend/service"
+	"github.com/gin-gonic/gin"
+)
+
+// StatisticsController 负责处理统计数据相关的 HTTP 请求。
+type StatisticsController struct {
+	service *service.StatisticsService
+}
+
+// NewStatisticsController 创建 StatisticsController 实例。
+func NewStatisticsController(service *service.StatisticsService) *StatisticsController {
+	return &StatisticsController{service: service}
+}
+
+// GetDashboardStats 获取 Dashboard 概览统计数据。
+// GET /statistics/dashboard
+func (c *StatisticsController) GetDashboardStats(ctx *gin.Context) {
+	stats, err := c.service.GetDashboardStats()
+	if err != nil {
+		log.Printf("获取Dashboard统计数据失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取统计数据失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, stats)
+}
+
+// GetConversationTrend 获取对话趋势数据。
+// GET /statistics/conversations/trend?days=7
+func (c *StatisticsController) GetConversationTrend(ctx *gin.Context) {
+	days := 7
+	if daysStr := ctx.Query("days"); daysStr != "" {
+		if d, err := strconv.Atoi(daysStr); err == nil && d > 0 {
+			days = d
+		}
+	}
+
+	trend, err := c.service.GetConversationTrend(days)
+	if err != nil {
+		log.Printf("获取对话趋势数据失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取趋势数据失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"trend": trend,
+		"days":  days,
+	})
+}
+
+// GetAgentWorkload 获取客服工作量统计。
+// GET /statistics/agents/workload?days=7
+func (c *StatisticsController) GetAgentWorkload(ctx *gin.Context) {
+	days := 7
+	if daysStr := ctx.Query("days"); daysStr != "" {
+		if d, err := strconv.Atoi(daysStr); err == nil && d > 0 {
+			days = d
+		}
+	}
+
+	workload, err := c.service.GetAgentWorkload(days)
+	if err != nil {
+		log.Printf("获取客服工作量数据失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取工作量数据失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"workload": workload,
+		"days":     days,
+	})
+}
+
+// GetVisitorAnalytics 获取访客分析数据。
+// GET /statistics/visitors?days=7
+func (c *StatisticsController) GetVisitorAnalytics(ctx *gin.Context) {
+	days := 7
+	if daysStr := ctx.Query("days"); daysStr != "" {
+		if d, err := strconv.Atoi(daysStr); err == nil && d > 0 {
+			days = d
+		}
+	}
+
+	analytics, err := c.service.GetVisitorAnalytics(days)
+	if err != nil {
+		log.Printf("获取访客分析数据失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取访客分析数据失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, analytics)
+}
+
+// GetAIStats 获取AI统计数据。
+// GET /statistics/ai?days=7
+func (c *StatisticsController) GetAIStats(ctx *gin.Context) {
+	days := 7
+	if daysStr := ctx.Query("days"); daysStr != "" {
+		if d, err := strconv.Atoi(daysStr); err == nil && d > 0 {
+			days = d
+		}
+	}
+
+	stats, err := c.service.GetAIStats(days)
+	if err != nil {
+		log.Printf("获取AI统计数据失败: %v", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "获取AI统计数据失败"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, stats)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 
 	//根据结构体定义自动创建更新表
-	if err := db.AutoMigrate(&models.User{}, &models.Conversation{}, &models.Message{}, &models.AIConfig{}, &models.FAQ{}, &models.KnowledgeBase{}, &models.Document{}, &models.EmbeddingConfig{}); err != nil {
+	if err := db.AutoMigrate(&models.User{}, &models.Conversation{}, &models.Message{}, &models.AIConfig{}, &models.FAQ{}, &models.KnowledgeBase{}, &models.Document{}, &models.EmbeddingConfig{}, &models.QuickReply{}); err != nil {
 		log.Fatalf("自动创建表失败： %v", err)
 	}
 
@@ -112,6 +112,8 @@ func main() {
 	kbRepo := repository.NewKnowledgeBaseRepository(db)
 	docRepo := repository.NewDocumentRepository(db)
 	embeddingConfigRepo := repository.NewEmbeddingConfigRepository(db)
+	quickReplyRepo := repository.NewQuickReplyRepository(db)
+	statisticsRepo := repository.NewStatisticsRepository(db)
 
 	// 初始化默认管理员账号（如果不存在）
 	initDefaultAdmin(userRepo)
@@ -195,6 +197,8 @@ func main() {
 	documentService := service.NewDocumentService(docRepo, kbRepo, documentEmbeddingService, retrievalService) // 文档管理服务
 	knowledgeBaseService := service.NewKnowledgeBaseService(kbRepo, docRepo)                                   // 知识库管理服务
 	importService := service.NewImportService(docRepo, kbRepo, documentService, documentEmbeddingService)      // 导入服务
+	quickReplyService := service.NewQuickReplyService(quickReplyRepo)                                          // 快捷回复服务
+	statisticsService := service.NewStatisticsService(statisticsRepo)                                          // 统计服务
 
 	// 声明 Hub 变量（用于在回调函数中访问）
 	var wsHub *websocket.Hub
@@ -318,6 +322,8 @@ func main() {
 	importController := controller.NewImportController(importService, embeddingConfigService) // 导入控制器
 	visitorController := controller.NewVisitorController(visitorService)
 	healthController := controller.NewHealthController(healthChecker, retrievalService) // 健康检查控制器
+	quickReplyController := controller.NewQuickReplyController(quickReplyService)       // 快捷回复控制器
+	statisticsController := controller.NewStatisticsController(statisticsService)       // 统计控制器
 
 	appRouter.RegisterRoutes(
 		r,
@@ -335,6 +341,8 @@ func main() {
 			Import:            importController, // 导入控制器
 			Visitor:           visitorController,
 			Health:            healthController, // 健康检查控制器
+			QuickReply:        quickReplyController,       // 快捷回复控制器
+			Statistics:        statisticsController,       // 统计控制器
 		},
 		websocket.HandleWebSocket(wsHub),
 	)

--- a/backend/models/quick_reply.go
+++ b/backend/models/quick_reply.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+)
+
+// QuickReply 快捷回复模板模型
+// 用于存储客服常用的回复模板，支持个人模板和公共模板
+type QuickReply struct {
+	ID         uint      `json:"id" gorm:"primaryKey"`
+	UserID     *uint     `json:"user_id" gorm:"index"`              // 所属用户ID（null表示公共模板）
+	Title      string    `json:"title" gorm:"type:varchar(100)"`    // 模板标题/快捷键
+	Content    string    `json:"content" gorm:"type:text;not null"` // 模板内容
+	Category   string    `json:"category" gorm:"type:varchar(50)"`  // 分类（如：问候、常见问题、结束语等）
+	SortOrder  int       `json:"sort_order" gorm:"default:0"`       // 排序（数值越小越靠前）
+	UsageCount int       `json:"usage_count" gorm:"default:0"`      // 使用次数统计
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// TableName 指定表名
+func (QuickReply) TableName() string {
+	return "quick_replies"
+}

--- a/backend/repository/quick_reply_repository.go
+++ b/backend/repository/quick_reply_repository.go
@@ -1,0 +1,106 @@
+package repository
+
+import (
+	"github.com/2930134478/AI-CS/backend/models"
+	"gorm.io/gorm"
+)
+
+// QuickReplyRepository 封装与快捷回复模板相关的数据库操作。
+type QuickReplyRepository struct {
+	db *gorm.DB
+}
+
+// NewQuickReplyRepository 创建快捷回复仓库实例。
+func NewQuickReplyRepository(db *gorm.DB) *QuickReplyRepository {
+	return &QuickReplyRepository{db: db}
+}
+
+// Create 创建新的快捷回复模板。
+func (r *QuickReplyRepository) Create(reply *models.QuickReply) error {
+	return r.db.Create(reply).Error
+}
+
+// GetByID 根据ID查询快捷回复模板。
+func (r *QuickReplyRepository) GetByID(id uint) (*models.QuickReply, error) {
+	var reply models.QuickReply
+	if err := r.db.First(&reply, id).Error; err != nil {
+		return nil, err
+	}
+	return &reply, nil
+}
+
+// Update 更新快捷回复模板。
+func (r *QuickReplyRepository) Update(reply *models.QuickReply) error {
+	return r.db.Save(reply).Error
+}
+
+// Delete 删除快捷回复模板。
+func (r *QuickReplyRepository) Delete(id uint) error {
+	return r.db.Delete(&models.QuickReply{}, id).Error
+}
+
+// ListByUserID 获取指定用户的个人模板列表。
+func (r *QuickReplyRepository) ListByUserID(userID uint) ([]models.QuickReply, error) {
+	var replies []models.QuickReply
+	if err := r.db.Where("user_id = ?", userID).
+		Order("sort_order ASC, created_at DESC").
+		Find(&replies).Error; err != nil {
+		return nil, err
+	}
+	return replies, nil
+}
+
+// ListPublic 获取公共模板列表（user_id 为 null）。
+func (r *QuickReplyRepository) ListPublic() ([]models.QuickReply, error) {
+	var replies []models.QuickReply
+	if err := r.db.Where("user_id IS NULL").
+		Order("sort_order ASC, created_at DESC").
+		Find(&replies).Error; err != nil {
+		return nil, err
+	}
+	return replies, nil
+}
+
+// ListByUserIDAndPublic 获取用户的个人模板和公共模板（合并列表）。
+func (r *QuickReplyRepository) ListByUserIDAndPublic(userID uint) ([]models.QuickReply, error) {
+	var replies []models.QuickReply
+	if err := r.db.Where("user_id = ? OR user_id IS NULL", userID).
+		Order("user_id DESC, sort_order ASC, created_at DESC"). // 个人模板优先
+		Find(&replies).Error; err != nil {
+		return nil, err
+	}
+	return replies, nil
+}
+
+// IncrementUsageCount 增加使用次数。
+func (r *QuickReplyRepository) IncrementUsageCount(id uint) error {
+	return r.db.Model(&models.QuickReply{}).
+		Where("id = ?", id).
+		UpdateColumn("usage_count", gorm.Expr("usage_count + 1")).Error
+}
+
+// ListByCategory 按分类获取模板列表。
+func (r *QuickReplyRepository) ListByCategory(userID uint, category string) ([]models.QuickReply, error) {
+	var replies []models.QuickReply
+	query := r.db.Where("user_id = ? OR user_id IS NULL", userID)
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+	if err := query.Order("user_id DESC, sort_order ASC, created_at DESC").
+		Find(&replies).Error; err != nil {
+		return nil, err
+	}
+	return replies, nil
+}
+
+// GetCategories 获取所有分类。
+func (r *QuickReplyRepository) GetCategories(userID uint) ([]string, error) {
+	var categories []string
+	if err := r.db.Model(&models.QuickReply{}).
+		Where("user_id = ? OR user_id IS NULL", userID).
+		Distinct("category").
+		Pluck("category", &categories).Error; err != nil {
+		return nil, err
+	}
+	return categories, nil
+}

--- a/backend/repository/statistics_repository.go
+++ b/backend/repository/statistics_repository.go
@@ -1,0 +1,244 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/2930134478/AI-CS/backend/models"
+	"gorm.io/gorm"
+)
+
+// StatisticsRepository 封装与统计数据相关的数据库操作。
+type StatisticsRepository struct {
+	db *gorm.DB
+}
+
+// NewStatisticsRepository 创建统计仓库实例。
+func NewStatisticsRepository(db *gorm.DB) *StatisticsRepository {
+	return &StatisticsRepository{db: db}
+}
+
+// GetTodayConversationCount 获取今日对话数。
+func (r *StatisticsRepository) GetTodayConversationCount() (int64, error) {
+	var count int64
+	today := time.Now().Format("2006-01-02")
+	err := r.db.Model(&models.Conversation{}).
+		Where("DATE(created_at) = ?", today).
+		Count(&count).Error
+	return count, err
+}
+
+// GetTodayMessageCount 获取今日消息数。
+func (r *StatisticsRepository) GetTodayMessageCount() (int64, error) {
+	var count int64
+	today := time.Now().Format("2006-01-02")
+	err := r.db.Model(&models.Message{}).
+		Where("DATE(created_at) = ?", today).
+		Where("message_type = ?", "user_message").
+		Count(&count).Error
+	return count, err
+}
+
+// GetTotalConversationCount 获取总对话数。
+func (r *StatisticsRepository) GetTotalConversationCount() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.Conversation{}).Count(&count).Error
+	return count, err
+}
+
+// GetTotalMessageCount 获取总消息数。
+func (r *StatisticsRepository) GetTotalMessageCount() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.Message{}).
+		Where("message_type = ?", "user_message").
+		Count(&count).Error
+	return count, err
+}
+
+// GetActiveVisitorCount 获取活跃访客数（有未关闭对话的访客）。
+func (r *StatisticsRepository) GetActiveVisitorCount() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.Conversation{}).
+		Where("conversation_type = ? AND status != ?", "visitor", "closed").
+		Distinct("visitor_id").
+		Count(&count).Error
+	return count, err
+}
+
+// GetConversationTrend 获取对话趋势数据（最近N天）。
+func (r *StatisticsRepository) GetConversationTrend(days int) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	// 获取最近N天的对话统计
+	query := `
+		SELECT
+			DATE(created_at) as date,
+			COUNT(*) as count
+		FROM conversations
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND conversation_type = 'visitor'
+		GROUP BY DATE(created_at)
+		ORDER BY date ASC
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetMessageTrend 获取消息趋势数据（最近N天）。
+func (r *StatisticsRepository) GetMessageTrend(days int) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	query := `
+		SELECT
+			DATE(created_at) as date,
+			COUNT(*) as count
+		FROM messages
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND message_type = 'user_message'
+		GROUP BY DATE(created_at)
+		ORDER BY date ASC
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetAgentWorkload 获取客服工作量统计。
+func (r *StatisticsRepository) GetAgentWorkload(startDate, endDate time.Time) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	query := `
+		SELECT
+			u.id as agent_id,
+			COALESCE(u.nickname, u.username) as agent_name,
+			COUNT(DISTINCT c.id) as conversation_count,
+			COUNT(m.id) as message_count
+		FROM users u
+		LEFT JOIN conversations c ON c.agent_id = u.id
+			AND c.conversation_type = 'visitor'
+			AND c.created_at BETWEEN ? AND ?
+		LEFT JOIN messages m ON m.sender_id = u.id
+			AND m.sender_is_agent = 1
+			AND m.message_type = 'user_message'
+			AND m.created_at BETWEEN ? AND ?
+		WHERE u.role IN ('admin', 'agent')
+		GROUP BY u.id, u.nickname, u.username
+		ORDER BY conversation_count DESC, message_count DESC
+	`
+
+	if err := r.db.Raw(query, startDate, endDate, startDate, endDate).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetVisitorSourceStats 获取访客来源统计。
+func (r *StatisticsRepository) GetVisitorSourceStats(days int) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	// 按网站来源统计
+	query := `
+		SELECT
+			CASE
+				WHEN website IS NULL OR website = '' THEN '未知'
+				WHEN website LIKE '%google%' THEN 'Google'
+				WHEN website LIKE '%baidu%' THEN '百度'
+				WHEN website LIKE '%bing%' THEN 'Bing'
+				WHEN website LIKE '%sogou%' THEN '搜狗'
+				ELSE '直接访问'
+			END as source,
+			COUNT(DISTINCT visitor_id) as count
+		FROM conversations
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND conversation_type = 'visitor'
+		GROUP BY source
+		ORDER BY count DESC
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetBrowserStats 获取浏览器统计。
+func (r *StatisticsRepository) GetBrowserStats(days int) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	query := `
+		SELECT
+			CASE
+				WHEN browser LIKE '%Chrome%' THEN 'Chrome'
+				WHEN browser LIKE '%Firefox%' THEN 'Firefox'
+				WHEN browser LIKE '%Safari%' THEN 'Safari'
+				WHEN browser LIKE '%Edge%' THEN 'Edge'
+				WHEN browser LIKE '%MSIE%' OR browser LIKE '%Trident%' THEN 'IE'
+				WHEN browser IS NULL OR browser = '' THEN '未知'
+				ELSE '其他'
+			END as browser,
+			COUNT(*) as count
+		FROM conversations
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND conversation_type = 'visitor'
+		GROUP BY browser
+		ORDER BY count DESC
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetAIResponseStats 获取AI回复统计。
+func (r *StatisticsRepository) GetAIResponseStats(days int) (map[string]interface{}, error) {
+	var results map[string]interface{}
+
+	// AI模式下的消息数
+	query := `
+		SELECT
+			COUNT(*) as total_ai_responses,
+			COUNT(CASE WHEN chat_mode = 'ai' THEN 1 END) as ai_mode_count,
+			COUNT(CASE WHEN chat_mode = 'human' THEN 1 END) as human_mode_count
+		FROM messages
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND sender_is_agent = 0
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetHourlyDistribution 获取对话时间分布（按小时）。
+func (r *StatisticsRepository) GetHourlyDistribution(days int) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	query := `
+		SELECT
+			HOUR(created_at) as hour,
+			COUNT(*) as count
+		FROM conversations
+		WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+			AND conversation_type = 'visitor'
+		GROUP BY HOUR(created_at)
+		ORDER BY hour ASC
+	`
+
+	if err := r.db.Raw(query, days).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -20,6 +20,8 @@ type ControllerSet struct {
 	Import           *controller.ImportController
 	Visitor          *controller.VisitorController
 	Health           *controller.HealthController
+	QuickReply       *controller.QuickReplyController
+	Statistics       *controller.StatisticsController
 }
 
 // RegisterRoutes 注册 HTTP 路由及对应的处理函数。
@@ -107,6 +109,22 @@ func RegisterRoutes(r *gin.Engine, controllers ControllerSet, wsHandler gin.Hand
 	// Health（健康检查）
 	r.GET("/health", controllers.Health.HealthCheck)       // 健康检查
 	r.GET("/health/metrics", controllers.Health.Metrics)   // 性能指标
+
+	// QuickReply（快捷回复模板）
+	r.GET("/quick-replies", controllers.QuickReply.ListQuickReplies)       // 获取模板列表
+	r.GET("/quick-replies/categories", controllers.QuickReply.GetCategories) // 获取分类列表
+	r.GET("/quick-replies/:id", controllers.QuickReply.GetQuickReply)      // 获取模板详情
+	r.POST("/quick-replies", controllers.QuickReply.CreateQuickReply)      // 创建模板
+	r.PUT("/quick-replies/:id", controllers.QuickReply.UpdateQuickReply)   // 更新模板
+	r.DELETE("/quick-replies/:id", controllers.QuickReply.DeleteQuickReply) // 删除模板
+	r.POST("/quick-replies/:id/use", controllers.QuickReply.RecordUsage)   // 记录使用
+
+	// Statistics（数据统计）
+	r.GET("/statistics/dashboard", controllers.Statistics.GetDashboardStats)         // Dashboard 概览
+	r.GET("/statistics/conversations/trend", controllers.Statistics.GetConversationTrend) // 对话趋势
+	r.GET("/statistics/agents/workload", controllers.Statistics.GetAgentWorkload)   // 客服工作量
+	r.GET("/statistics/visitors", controllers.Statistics.GetVisitorAnalytics)        // 访客分析
+	r.GET("/statistics/ai", controllers.Statistics.GetAIStats)                       // AI 统计
 
 	// WebSocket
 	r.GET("/ws", wsHandler)

--- a/backend/service/quick_reply_service.go
+++ b/backend/service/quick_reply_service.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/2930134478/AI-CS/backend/models"
+	"github.com/2930134478/AI-CS/backend/repository"
+	"gorm.io/gorm"
+)
+
+// QuickReplyService 负责快捷回复模板管理领域的业务编排。
+type QuickReplyService struct {
+	repo *repository.QuickReplyRepository
+}
+
+// NewQuickReplyService 创建 QuickReplyService 实例。
+func NewQuickReplyService(repo *repository.QuickReplyRepository) *QuickReplyService {
+	return &QuickReplyService{repo: repo}
+}
+
+// CreateQuickReply 创建新的快捷回复模板。
+func (s *QuickReplyService) CreateQuickReply(input CreateQuickReplyInput) (*QuickReplySummary, error) {
+	// 验证必填字段
+	if input.Content == "" {
+		return nil, errors.New("模板内容不能为空")
+	}
+
+	// 设置默认标题
+	title := input.Title
+	if title == "" {
+		// 如果没有标题，取内容前20个字符作为标题
+		if len(input.Content) > 20 {
+			title = input.Content[:20] + "..."
+		} else {
+			title = input.Content
+		}
+	}
+
+	reply := &models.QuickReply{
+		UserID:    input.UserID,
+		Title:     title,
+		Content:   input.Content,
+		Category:  input.Category,
+		SortOrder: input.SortOrder,
+	}
+
+	if err := s.repo.Create(reply); err != nil {
+		return nil, err
+	}
+
+	return s.toSummary(reply), nil
+}
+
+// UpdateQuickReply 更新快捷回复模板。
+func (s *QuickReplyService) UpdateQuickReply(id uint, input UpdateQuickReplyInput, userID *uint) (*QuickReplySummary, error) {
+	reply, err := s.repo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("模板不存在")
+		}
+		return nil, err
+	}
+
+	// 权限检查：只能修改自己的模板或公共模板（管理员可以修改公共模板）
+	if reply.UserID != nil && userID != nil && *reply.UserID != *userID {
+		return nil, errors.New("无权修改此模板")
+	}
+
+	// 更新字段
+	if input.Title != nil {
+		reply.Title = *input.Title
+	}
+	if input.Content != nil {
+		if *input.Content == "" {
+			return nil, errors.New("模板内容不能为空")
+		}
+		reply.Content = *input.Content
+	}
+	if input.Category != nil {
+		reply.Category = *input.Category
+	}
+	if input.SortOrder != nil {
+		reply.SortOrder = *input.SortOrder
+	}
+
+	if err := s.repo.Update(reply); err != nil {
+		return nil, err
+	}
+
+	return s.toSummary(reply), nil
+}
+
+// DeleteQuickReply 删除快捷回复模板。
+func (s *QuickReplyService) DeleteQuickReply(id uint, userID *uint) error {
+	reply, err := s.repo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("模板不存在")
+		}
+		return err
+	}
+
+	// 权限检查：只能删除自己的模板
+	if reply.UserID != nil && userID != nil && *reply.UserID != *userID {
+		return errors.New("无权删除此模板")
+	}
+
+	return s.repo.Delete(id)
+}
+
+// GetQuickReply 获取快捷回复模板详情。
+func (s *QuickReplyService) GetQuickReply(id uint) (*QuickReplySummary, error) {
+	reply, err := s.repo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("模板不存在")
+		}
+		return nil, err
+	}
+
+	return s.toSummary(reply), nil
+}
+
+// ListQuickReplies 获取快捷回复模板列表（个人+公共）。
+func (s *QuickReplyService) ListQuickReplies(userID uint, category string) ([]QuickReplySummary, error) {
+	var replies []models.QuickReply
+	var err error
+
+	if category != "" {
+		replies, err = s.repo.ListByCategory(userID, category)
+	} else {
+		replies, err = s.repo.ListByUserIDAndPublic(userID)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	summaries := make([]QuickReplySummary, 0, len(replies))
+	for _, reply := range replies {
+		summaries = append(summaries, *s.toSummary(&reply))
+	}
+
+	return summaries, nil
+}
+
+// RecordUsage 记录模板使用（增加使用次数）。
+func (s *QuickReplyService) RecordUsage(id uint) error {
+	return s.repo.IncrementUsageCount(id)
+}
+
+// GetCategories 获取所有分类。
+func (s *QuickReplyService) GetCategories(userID uint) ([]string, error) {
+	return s.repo.GetCategories(userID)
+}
+
+// toSummary 将模型转换为摘要。
+func (s *QuickReplyService) toSummary(reply *models.QuickReply) *QuickReplySummary {
+	var userID *uint
+	if reply.UserID != nil {
+		userID = reply.UserID
+	}
+	return &QuickReplySummary{
+		ID:         reply.ID,
+		UserID:     userID,
+		Title:      reply.Title,
+		Content:    reply.Content,
+		Category:   reply.Category,
+		SortOrder:  reply.SortOrder,
+		UsageCount: reply.UsageCount,
+		CreatedAt:  reply.CreatedAt,
+		UpdatedAt:  reply.UpdatedAt,
+	}
+}

--- a/backend/service/statistics_service.go
+++ b/backend/service/statistics_service.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"time"
+
+	"github.com/2930134478/AI-CS/backend/repository"
+)
+
+// StatisticsService 负责统计数据相关的业务编排。
+type StatisticsService struct {
+	repo *repository.StatisticsRepository
+}
+
+// NewStatisticsService 创建 StatisticsService 实例。
+func NewStatisticsService(repo *repository.StatisticsRepository) *StatisticsService {
+	return &StatisticsService{repo: repo}
+}
+
+// GetDashboardStats 获取 Dashboard 概览统计数据。
+func (s *StatisticsService) GetDashboardStats() (*DashboardStats, error) {
+	// 并发获取各项统计数据
+	todayConv, err := s.repo.GetTodayConversationCount()
+	if err != nil {
+		return nil, err
+	}
+
+	todayMsg, err := s.repo.GetTodayMessageCount()
+	if err != nil {
+		return nil, err
+	}
+
+	activeVisitors, err := s.repo.GetActiveVisitorCount()
+	if err != nil {
+		return nil, err
+	}
+
+	totalConv, err := s.repo.GetTotalConversationCount()
+	if err != nil {
+		return nil, err
+	}
+
+	totalMsg, err := s.repo.GetTotalMessageCount()
+	if err != nil {
+		return nil, err
+	}
+
+	return &DashboardStats{
+		TodayConversations: todayConv,
+		TodayMessages:      todayMsg,
+		OnlineAgents:       0, // 在线客服数需要从 WebSocket Hub 获取，暂时设为0
+		ActiveVisitors:     activeVisitors,
+		TotalConversations: totalConv,
+		TotalMessages:      totalMsg,
+	}, nil
+}
+
+// GetConversationTrend 获取对话趋势数据。
+func (s *StatisticsService) GetConversationTrend(days int) ([]ConversationTrendData, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if days > 30 {
+		days = 30
+	}
+
+	// 获取对话趋势
+	convTrend, err := s.repo.GetConversationTrend(days)
+	if err != nil {
+		return nil, err
+	}
+
+	// 获取消息趋势
+	msgTrend, err := s.repo.GetMessageTrend(days)
+	if err != nil {
+		return nil, err
+	}
+
+	// 合并数据
+	msgMap := make(map[string]int64)
+	for _, item := range msgTrend {
+		if date, ok := item["date"].(time.Time); ok {
+			msgMap[date.Format("2006-01-02")] = item["count"].(int64)
+		}
+	}
+
+	results := make([]ConversationTrendData, 0, len(convTrend))
+	for _, item := range convTrend {
+		var dateStr string
+		if date, ok := item["date"].(time.Time); ok {
+			dateStr = date.Format("2006-01-02")
+		} else {
+			continue
+		}
+
+		count, _ := item["count"].(int64)
+		msgCount := msgMap[dateStr]
+
+		results = append(results, ConversationTrendData{
+			Date:         dateStr,
+			Count:        count,
+			MessageCount: msgCount,
+		})
+	}
+
+	return results, nil
+}
+
+// GetAgentWorkload 获取客服工作量统计。
+func (s *StatisticsService) GetAgentWorkload(days int) ([]AgentWorkloadData, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if days > 30 {
+		days = 30
+	}
+
+	startDate := time.Now().AddDate(0, 0, -days)
+	endDate := time.Now()
+
+	results, err := s.repo.GetAgentWorkload(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	workload := make([]AgentWorkloadData, 0, len(results))
+	for _, item := range results {
+		agentID, _ := item["agent_id"].(uint)
+		agentName, _ := item["agent_name"].(string)
+		convCount, _ := item["conversation_count"].(int64)
+		msgCount, _ := item["message_count"].(int64)
+
+		workload = append(workload, AgentWorkloadData{
+			AgentID:           agentID,
+			AgentName:         agentName,
+			ConversationCount: convCount,
+			MessageCount:      msgCount,
+			AvgResponseTime:   0, // 平均响应时间计算较复杂，暂设为0
+		})
+	}
+
+	return workload, nil
+}
+
+// GetVisitorAnalytics 获取访客分析数据。
+func (s *StatisticsService) GetVisitorAnalytics(days int) (map[string]interface{}, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if days > 30 {
+		days = 30
+	}
+
+	// 获取来源统计
+	sourceStats, err := s.repo.GetVisitorSourceStats(days)
+	if err != nil {
+		return nil, err
+	}
+
+	// 获取浏览器统计
+	browserStats, err := s.repo.GetBrowserStats(days)
+	if err != nil {
+		return nil, err
+	}
+
+	// 获取时间分布
+	hourlyDist, err := s.repo.GetHourlyDistribution(days)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"sources":      sourceStats,
+		"browsers":     browserStats,
+		"hourly_dist":  hourlyDist,
+	}, nil
+}
+
+// GetAIStats 获取AI统计数据。
+func (s *StatisticsService) GetAIStats(days int) (*AIStatsData, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if days > 30 {
+		days = 30
+	}
+
+	stats, err := s.repo.GetAIResponseStats(days)
+	if err != nil {
+		return nil, err
+	}
+
+	totalResponses, _ := stats["total_ai_responses"].(int64)
+	aiModeCount, _ := stats["ai_mode_count"].(int64)
+
+	var aiResponseRate float64
+	if totalResponses > 0 {
+		aiResponseRate = float64(aiModeCount) / float64(totalResponses) * 100
+	}
+
+	return &AIStatsData{
+		TotalAIResponses:  aiModeCount,
+		AIResponseRate:    aiResponseRate,
+		AvgResponseTime:   0, // 平均响应时间需要额外计算
+		HumanTakeoverRate: 0, // 人工接管率需要额外计算
+	}, nil
+}

--- a/backend/service/types.go
+++ b/backend/service/types.go
@@ -263,3 +263,74 @@ type UpdateKnowledgeBaseInput struct {
 	Description *string // 知识库描述（可选）
 	RAGEnabled  *bool   // 是否参与 RAG（可选）
 }
+
+// QuickReplySummary 快捷回复模板摘要信息。
+type QuickReplySummary struct {
+	ID         uint      `json:"id"`
+	UserID     *uint     `json:"user_id"`     // 所属用户ID（null表示公共模板）
+	Title      string    `json:"title"`       // 模板标题
+	Content    string    `json:"content"`     // 模板内容
+	Category   string    `json:"category"`    // 分类
+	SortOrder  int       `json:"sort_order"`  // 排序
+	UsageCount int       `json:"usage_count"` // 使用次数
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// CreateQuickReplyInput 创建快捷回复模板输入。
+type CreateQuickReplyInput struct {
+	UserID    *uint   // 所属用户ID（nil表示公共模板，仅管理员可创建）
+	Title     string  // 模板标题（可选，不填则自动取内容前20字）
+	Content   string  // 模板内容（必需）
+	Category  string  // 分类（可选）
+	SortOrder int     // 排序（可选）
+}
+
+// UpdateQuickReplyInput 更新快捷回复模板输入。
+type UpdateQuickReplyInput struct {
+	Title     *string // 模板标题（可选）
+	Content   *string // 模板内容（可选）
+	Category  *string // 分类（可选）
+	SortOrder *int    // 排序（可选）
+}
+
+// DashboardStats Dashboard 概览统计数据。
+type DashboardStats struct {
+	TodayConversations int64 `json:"today_conversations"` // 今日对话数
+	TodayMessages      int64 `json:"today_messages"`      // 今日消息数
+	OnlineAgents       int64 `json:"online_agents"`       // 在线客服数
+	ActiveVisitors     int64 `json:"active_visitors"`     // 活跃访客数
+	TotalConversations int64 `json:"total_conversations"` // 总对话数
+	TotalMessages      int64 `json:"total_messages"`      // 总消息数
+}
+
+// ConversationTrendData 对话趋势数据。
+type ConversationTrendData struct {
+	Date          string `json:"date"`           // 日期
+	Count         int64  `json:"count"`          // 对话数
+	MessageCount  int64  `json:"message_count"`  // 消息数
+	VisitorCount  int64  `json:"visitor_count"`  // 访客数
+}
+
+// AgentWorkloadData 客服工作量数据。
+type AgentWorkloadData struct {
+	AgentID           uint   `json:"agent_id"`
+	AgentName         string `json:"agent_name"`
+	ConversationCount int64  `json:"conversation_count"` // 对话数
+	MessageCount      int64  `json:"message_count"`      // 消息数
+	AvgResponseTime   int64  `json:"avg_response_time"`  // 平均响应时间（秒）
+}
+
+// VisitorSourceData 访客来源数据。
+type VisitorSourceData struct {
+	Source string `json:"source"` // 来源
+	Count  int64  `json:"count"`  // 数量
+}
+
+// AIStatsData AI 统计数据。
+type AIStatsData struct {
+	TotalAIResponses  int64   `json:"total_ai_responses"`  // AI 总回复数
+	AIResponseRate    float64 `json:"ai_response_rate"`    // AI 回复率
+	AvgResponseTime   int64   `json:"avg_response_time"`   // 平均响应时间（毫秒）
+	HumanTakeoverRate float64 `json:"human_takeover_rate"` // 人工接管率
+}

--- a/frontend/app/agent/quick-replies/page.tsx
+++ b/frontend/app/agent/quick-replies/page.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/features/agent/hooks/useAuth";
+import { ResponsiveLayout } from "@/components/layout";
+import {
+  fetchQuickReplies,
+  createQuickReply,
+  updateQuickReply,
+  deleteQuickReply,
+  fetchQuickReplyCategories,
+  type QuickReplySummary,
+  type CreateQuickReplyRequest,
+  type UpdateQuickReplyRequest,
+} from "@/features/agent/services/quickReplyApi";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Plus,
+  Edit,
+  Trash2,
+  MessageSquare,
+  Copy,
+  Star,
+} from "lucide-react";
+import { toast } from "@/hooks/useToast";
+import { Textarea } from "@/components/ui/textarea";
+
+// 预设分类
+const PRESET_CATEGORIES = ["问候", "常见问题", "产品介绍", "结束语", "其他"];
+
+export default function QuickRepliesPage(props: any = {}) {
+  const { embedded = false } = props;
+  const router = useRouter();
+  const { agent } = useAuth();
+  const [quickReplies, setQuickReplies] = useState<QuickReplySummary[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [selectedReply, setSelectedReply] = useState<QuickReplySummary | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 创建表单
+  const [createForm, setCreateForm] = useState<CreateQuickReplyRequest>({
+    content: "",
+    title: "",
+    category: "",
+  });
+
+  // 编辑表单
+  const [editForm, setEditForm] = useState<UpdateQuickReplyRequest>({});
+
+  // 加载模板列表
+  const loadQuickReplies = useCallback(async () => {
+    if (!agent?.id) return;
+    setLoading(true);
+    try {
+      const [data, cats] = await Promise.all([
+        fetchQuickReplies(agent.id, selectedCategory),
+        fetchQuickReplyCategories(agent.id),
+      ]);
+      setQuickReplies(data);
+      // 合并预设分类和实际分类
+      const allCategories = [...new Set([...PRESET_CATEGORIES, ...cats])];
+      setCategories(allCategories.filter(c => c));
+    } catch (error) {
+      console.error("加载快捷回复模板失败:", error);
+      toast.error((error as Error).message || "加载快捷回复模板失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [agent?.id, selectedCategory]);
+
+  useEffect(() => {
+    loadQuickReplies();
+  }, [loadQuickReplies]);
+
+  // 打开创建对话框
+  const handleOpenCreate = () => {
+    setCreateForm({
+      content: "",
+      title: "",
+      category: "",
+    });
+    setCreateDialogOpen(true);
+  };
+
+  // 创建模板
+  const handleCreate = async () => {
+    if (!createForm.content.trim()) {
+      toast.error("模板内容不能为空");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createQuickReply({
+        ...createForm,
+        user_id: agent?.id,
+      });
+      setCreateDialogOpen(false);
+      setCreateForm({ content: "", title: "", category: "" });
+      await loadQuickReplies();
+      toast.success("创建成功");
+    } catch (error) {
+      toast.error((error as Error).message || "创建失败");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // 打开编辑对话框
+  const handleOpenEdit = (reply: QuickReplySummary) => {
+    setSelectedReply(reply);
+    setEditForm({
+      title: reply.title,
+      content: reply.content,
+      category: reply.category,
+      sort_order: reply.sort_order,
+      user_id: agent?.id,
+    });
+    setEditDialogOpen(true);
+  };
+
+  // 更新模板
+  const handleUpdate = async () => {
+    if (!selectedReply) return;
+    if (!editForm.content?.trim()) {
+      toast.error("模板内容不能为空");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await updateQuickReply(selectedReply.id, editForm);
+      setEditDialogOpen(false);
+      setSelectedReply(null);
+      await loadQuickReplies();
+      toast.success("更新成功");
+    } catch (error) {
+      toast.error((error as Error).message || "更新失败");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // 打开删除对话框
+  const handleOpenDelete = (reply: QuickReplySummary) => {
+    setSelectedReply(reply);
+    setDeleteDialogOpen(true);
+  };
+
+  // 删除模板
+  const handleDelete = async () => {
+    if (!selectedReply) return;
+    setSubmitting(true);
+    try {
+      await deleteQuickReply(selectedReply.id, agent?.id);
+      setDeleteDialogOpen(false);
+      setSelectedReply(null);
+      await loadQuickReplies();
+      toast.success("删除成功");
+    } catch (error) {
+      toast.error((error as Error).message || "删除失败");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // 复制内容
+  const handleCopy = async (content: string) => {
+    try {
+      await navigator.clipboard.writeText(content);
+      toast.success("已复制到剪贴板");
+    } catch {
+      toast.error("复制失败");
+    }
+  };
+
+  // 判断是否是公共模板
+  const isPublicReply = (reply: QuickReplySummary) => reply.user_id === null;
+
+  // 头部内容
+  const headerContent = (
+    <div className="bg-card border-b p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold text-foreground">快捷回复</h1>
+        {!embedded && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push("/agent/dashboard")}
+          >
+            返回
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+        <div className="flex gap-2 flex-wrap">
+          <Button
+            variant={selectedCategory === "" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setSelectedCategory("")}
+          >
+            全部
+          </Button>
+          {categories.map((cat) => (
+            <Button
+              key={cat}
+              variant={selectedCategory === cat ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedCategory(cat)}
+            >
+              {cat}
+            </Button>
+          ))}
+        </div>
+        <div className="flex-1" />
+        <Button onClick={handleOpenCreate} className="w-full sm:w-auto">
+          <Plus className="w-4 h-4 mr-2" />
+          新建模板
+        </Button>
+      </div>
+    </div>
+  );
+
+  // 主内容区
+  const mainContent = (
+    <div className="flex-1 overflow-y-auto p-4 scrollbar-auto">
+      {loading ? (
+        <div className="flex items-center justify-center h-full">
+          <span className="text-muted-foreground">加载中...</span>
+        </div>
+      ) : quickReplies.length === 0 ? (
+        <div className="flex items-center justify-center h-full">
+          <span className="text-muted-foreground">
+            {selectedCategory ? "该分类下暂无模板" : "暂无快捷回复模板"}
+          </span>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {quickReplies.map((reply) => (
+            <Card key={reply.id} className="p-4 flex flex-col">
+              <div className="flex-1 mb-3">
+                <div className="flex items-start justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <MessageSquare className="w-5 h-5 text-blue-600 flex-shrink-0" />
+                    <h3 className="font-medium text-foreground line-clamp-1">
+                      {reply.title}
+                    </h3>
+                  </div>
+                  {isPublicReply(reply) && (
+                    <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex items-center gap-1">
+                      <Star className="w-3 h-3" />
+                      公共
+                    </span>
+                  )}
+                </div>
+                <div className="text-sm text-muted-foreground mb-2 line-clamp-3 whitespace-pre-wrap">
+                  {reply.content}
+                </div>
+                {reply.category && (
+                  <div className="text-xs text-muted-foreground mb-2">
+                    分类: {reply.category}
+                  </div>
+                )}
+                <div className="text-xs text-muted-foreground">
+                  使用次数: {reply.usage_count}
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 mt-3 pt-3 border-t border-border">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopy(reply.content)}
+                  className="flex-1"
+                >
+                  <Copy className="w-4 h-4 mr-1" />
+                  复制
+                </Button>
+                {!isPublicReply(reply) && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleOpenEdit(reply)}
+                    >
+                      <Edit className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleOpenDelete(reply)}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  // 嵌入模式
+  if (embedded) {
+    return (
+      <>
+        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+          {headerContent}
+          {mainContent}
+        </div>
+
+        {/* 创建模板对话框 */}
+        <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle>新建快捷回复</DialogTitle>
+              <DialogDescription>创建一个常用的回复模板</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="create-title">标题（可选）</Label>
+                <Input
+                  id="create-title"
+                  value={createForm.title || ""}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, title: e.target.value })
+                  }
+                  placeholder="不填则自动取内容前20字"
+                />
+              </div>
+              <div>
+                <Label htmlFor="create-content">内容 *</Label>
+                <Textarea
+                  id="create-content"
+                  value={createForm.content}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, content: e.target.value })
+                  }
+                  placeholder="输入模板内容"
+                  rows={4}
+                  className="resize-none"
+                />
+              </div>
+              <div>
+                <Label htmlFor="create-category">分类</Label>
+                <Input
+                  id="create-category"
+                  value={createForm.category || ""}
+                  onChange={(e) =>
+                    setCreateForm({ ...createForm, category: e.target.value })
+                  }
+                  placeholder="选择或输入分类"
+                  list="categories"
+                />
+                <datalist id="categories">
+                  {PRESET_CATEGORIES.map((cat) => (
+                    <option key={cat} value={cat} />
+                  ))}
+                </datalist>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setCreateDialogOpen(false)}
+                  disabled={submitting}
+                >
+                  取消
+                </Button>
+                <Button onClick={handleCreate} disabled={submitting}>
+                  {submitting ? "创建中..." : "创建"}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        {/* 编辑模板对话框 */}
+        <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle>编辑快捷回复</DialogTitle>
+            </DialogHeader>
+            {selectedReply && (
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="edit-title">标题</Label>
+                  <Input
+                    id="edit-title"
+                    value={editForm.title || ""}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, title: e.target.value })
+                    }
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="edit-content">内容 *</Label>
+                  <Textarea
+                    id="edit-content"
+                    value={editForm.content || ""}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, content: e.target.value })
+                    }
+                    rows={4}
+                    className="resize-none"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="edit-category">分类</Label>
+                  <Input
+                    id="edit-category"
+                    value={editForm.category || ""}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, category: e.target.value })
+                    }
+                    list="categories"
+                  />
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setEditDialogOpen(false)}
+                    disabled={submitting}
+                  >
+                    取消
+                  </Button>
+                  <Button onClick={handleUpdate} disabled={submitting}>
+                    {submitting ? "更新中..." : "更新"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+
+        {/* 删除确认对话框 */}
+        <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>删除快捷回复</DialogTitle>
+            </DialogHeader>
+            {selectedReply && (
+              <div className="space-y-4">
+                <p className="text-foreground">
+                  确定要删除模板 <strong>&quot;{selectedReply.title}&quot;</strong> 吗？
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setDeleteDialogOpen(false)}
+                    disabled={submitting}
+                  >
+                    取消
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleDelete}
+                    disabled={submitting}
+                  >
+                    {submitting ? "删除中..." : "删除"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  }
+
+  return (
+    <ResponsiveLayout main={mainContent} header={headerContent} />
+  );
+}

--- a/frontend/app/agent/statistics/page.tsx
+++ b/frontend/app/agent/statistics/page.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/features/agent/hooks/useAuth";
+import { ResponsiveLayout } from "@/components/layout";
+import {
+  fetchDashboardStats,
+  fetchConversationTrend,
+  fetchAgentWorkload,
+  fetchVisitorAnalytics,
+  type DashboardStats,
+  type ConversationTrendData,
+  type AgentWorkloadData,
+  type VisitorSourceData,
+} from "@/features/agent/services/statisticsApi";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  MessageCircle,
+  Users,
+  UserCheck,
+  Activity,
+  TrendingUp,
+  BarChart3,
+  PieChart as PieChartIcon,
+  ArrowLeft,
+} from "lucide-react";
+import { toast } from "@/hooks/useToast";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+// 颜色配置
+const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
+
+// 时间范围选项
+const TIME_RANGES = [
+  { value: 7, label: "近7天" },
+  { value: 14, label: "近14天" },
+  { value: 30, label: "近30天" },
+];
+
+export default function StatisticsPage(props: any = {}) {
+  const { embedded = false } = props;
+  const router = useRouter();
+  const { agent } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(7);
+
+  // 统计数据
+  const [dashboardStats, setDashboardStats] = useState<DashboardStats | null>(null);
+  const [trendData, setTrendData] = useState<ConversationTrendData[]>([]);
+  const [workloadData, setWorkloadData] = useState<AgentWorkloadData[]>([]);
+  const [sourceData, setSourceData] = useState<VisitorSourceData[]>([]);
+
+  // 加载统计数据
+  const loadStatistics = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [dashboard, trend, workload, visitor] = await Promise.all([
+        fetchDashboardStats(),
+        fetchConversationTrend(days),
+        fetchAgentWorkload(days),
+        fetchVisitorAnalytics(days),
+      ]);
+
+      setDashboardStats(dashboard);
+      setTrendData(trend.trend);
+      setWorkloadData(workload.workload);
+      setSourceData(visitor.sources);
+    } catch (error) {
+      console.error("加载统计数据失败:", error);
+      toast.error((error as Error).message || "加载统计数据失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    loadStatistics();
+  }, [loadStatistics]);
+
+  // 概览卡片
+  const StatCard = ({
+    title,
+    value,
+    icon: Icon,
+    description,
+  }: {
+    title: string;
+    value: number;
+    icon: React.ElementType;
+    description?: string;
+  }) => (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value.toLocaleString()}</div>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  // 头部内容
+  const headerContent = (
+    <div className="bg-card border-b p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold text-foreground">数据统计</h1>
+        {!embedded && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push("/agent/dashboard")}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            返回
+          </Button>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {TIME_RANGES.map((range) => (
+          <Button
+            key={range.value}
+            variant={days === range.value ? "default" : "outline"}
+            size="sm"
+            onClick={() => setDays(range.value)}
+          >
+            {range.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+
+  // 主内容区
+  const mainContent = (
+    <div className="flex-1 overflow-y-auto p-4 scrollbar-auto">
+      {loading ? (
+        <div className="flex items-center justify-center h-full">
+          <span className="text-muted-foreground">加载中...</span>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* 概览卡片 */}
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              title="今日对话"
+              value={dashboardStats?.today_conversations || 0}
+              icon={MessageCircle}
+              description="今日新增对话数"
+            />
+            <StatCard
+              title="今日消息"
+              value={dashboardStats?.today_messages || 0}
+              icon={Activity}
+              description="今日发送消息数"
+            />
+            <StatCard
+              title="活跃访客"
+              value={dashboardStats?.active_visitors || 0}
+              icon={Users}
+              description="有活跃对话的访客"
+            />
+            <StatCard
+              title="总对话数"
+              value={dashboardStats?.total_conversations || 0}
+              icon={TrendingUp}
+              description="系统累计对话数"
+            />
+          </div>
+
+          {/* 对话趋势图表 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <TrendingUp className="w-5 h-5" />
+                对话趋势
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {trendData.length > 0 ? (
+                <ResponsiveContainer width="100%" height={300}>
+                  <LineChart data={trendData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={(value) => value.slice(5)}
+                    />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend />
+                    <Line
+                      type="monotone"
+                      dataKey="count"
+                      name="对话数"
+                      stroke="#3b82f6"
+                      strokeWidth={2}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="message_count"
+                      name="消息数"
+                      stroke="#10b981"
+                      strokeWidth={2}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="h-[300px] flex items-center justify-center text-muted-foreground">
+                  暂无数据
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* 客服工作量和访客来源 */}
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* 客服工作量 */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <BarChart3 className="w-5 h-5" />
+                  客服工作量
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {workloadData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={workloadData.slice(0, 10)} layout="vertical">
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis type="number" />
+                      <YAxis dataKey="agent_name" type="category" width={80} />
+                      <Tooltip />
+                      <Legend />
+                      <Bar dataKey="conversation_count" name="对话数" fill="#3b82f6" />
+                      <Bar dataKey="message_count" name="消息数" fill="#10b981" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-[300px] flex items-center justify-center text-muted-foreground">
+                    暂无数据
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* 访客来源 */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <PieChartIcon className="w-5 h-5" />
+                  访客来源
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {sourceData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={300}>
+                    <PieChart>
+                      <Pie
+                        data={sourceData}
+                        cx="50%"
+                        cy="50%"
+                        labelLine={false}
+                        label={({ source, percent }) =>
+                          `${source} ${(percent * 100).toFixed(0)}%`
+                        }
+                        outerRadius={80}
+                        fill="#8884d8"
+                        dataKey="count"
+                        nameKey="source"
+                      >
+                        {sourceData.map((_, index) => (
+                          <Cell
+                            key={`cell-${index}`}
+                            fill={COLORS[index % COLORS.length]}
+                          />
+                        ))}
+                      </Pie>
+                      <Tooltip />
+                    </PieChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-[300px] flex items-center justify-center text-muted-foreground">
+                    暂无数据
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* 客服工作量表格 */}
+          {workloadData.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>客服工作量详情</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="text-left py-2 px-4">客服</th>
+                        <th className="text-right py-2 px-4">对话数</th>
+                        <th className="text-right py-2 px-4">回复消息数</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {workloadData.map((item) => (
+                        <tr key={item.agent_id} className="border-b">
+                          <td className="py-2 px-4">{item.agent_name}</td>
+                          <td className="text-right py-2 px-4">
+                            {item.conversation_count}
+                          </td>
+                          <td className="text-right py-2 px-4">
+                            {item.message_count}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  // 嵌入模式
+  if (embedded) {
+    return (
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        {headerContent}
+        {mainContent}
+      </div>
+    );
+  }
+
+  return <ResponsiveLayout main={mainContent} header={headerContent} />;
+}

--- a/frontend/components/dashboard/DashboardShell.tsx
+++ b/frontend/components/dashboard/DashboardShell.tsx
@@ -295,6 +295,7 @@ export function DashboardShell() {
               onSubmit={handleSendMessage}
               sending={sending}
               conversationId={selectedConversationId ?? undefined}
+              agentId={agent?.id}
             />
           </>
         ) : (

--- a/frontend/components/dashboard/MessageInput.tsx
+++ b/frontend/components/dashboard/MessageInput.tsx
@@ -4,8 +4,13 @@ import { FormEvent, useEffect, useRef, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { uploadFile, UploadFileResult } from "@/features/agent/services/messageApi";
-import { X, Paperclip, Image as ImageIcon } from "lucide-react";
+import { X, Paperclip, Zap, ChevronDown } from "lucide-react";
 import { toast } from "@/hooks/useToast";
+import {
+  fetchQuickReplies,
+  recordQuickReplyUsage,
+  type QuickReplySummary,
+} from "@/features/agent/services/quickReplyApi";
 
 interface MessageInputProps {
   value: string;
@@ -13,6 +18,7 @@ interface MessageInputProps {
   onSubmit: (fileInfo?: UploadFileResult) => Promise<void> | void;
   sending: boolean;
   conversationId?: number; // 对话ID，用于文件上传
+  agentId?: number; // 客服ID，用于获取快捷回复
 }
 
 interface FilePreview {
@@ -26,6 +32,7 @@ export function MessageInput({
   onSubmit,
   sending,
   conversationId,
+  agentId,
 }: MessageInputProps) {
   // 输入框引用，用于发送消息后自动聚焦
   const inputRef = useRef<HTMLInputElement>(null);
@@ -37,6 +44,36 @@ export function MessageInput({
   const [filePreview, setFilePreview] = useState<FilePreview | null>(null);
   // 上传中状态
   const [uploading, setUploading] = useState(false);
+  // 快捷回复状态
+  const [quickReplies, setQuickReplies] = useState<QuickReplySummary[]>([]);
+  const [showQuickReplies, setShowQuickReplies] = useState(false);
+  const quickReplyRef = useRef<HTMLDivElement>(null);
+
+  // 加载快捷回复
+  useEffect(() => {
+    if (agentId) {
+      fetchQuickReplies(agentId)
+        .then(setQuickReplies)
+        .catch(console.error);
+    }
+  }, [agentId]);
+
+  // 点击外部关闭快捷回复面板
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        quickReplyRef.current &&
+        !quickReplyRef.current.contains(event.target as Node)
+      ) {
+        setShowQuickReplies(false);
+      }
+    };
+
+    if (showQuickReplies) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showQuickReplies]);
 
   // 当发送状态从 true 变为 false 时（发送完成），自动聚焦到输入框
   useEffect(() => {
@@ -157,6 +194,20 @@ export function MessageInput({
     return (bytes / (1024 * 1024)).toFixed(1) + " MB";
   };
 
+  // 处理快捷回复选择
+  const handleQuickReplySelect = useCallback(
+    (reply: QuickReplySummary) => {
+      // 将内容插入到输入框
+      onChange(value ? value + "\n" + reply.content : reply.content);
+      setShowQuickReplies(false);
+      // 记录使用
+      recordQuickReplyUsage(reply.id).catch(console.error);
+      // 聚焦输入框
+      inputRef.current?.focus();
+    },
+    [value, onChange]
+  );
+
   // 处理提交
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -273,6 +324,48 @@ export function MessageInput({
         >
           <Paperclip className="w-4 h-4" />
         </Button>
+
+        {/* 快捷回复按钮 */}
+        {quickReplies.length > 0 && (
+          <div className="relative" ref={quickReplyRef}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowQuickReplies(!showQuickReplies)}
+              disabled={sending || uploading}
+              title="快捷回复"
+              className="hover:bg-primary/10 hover:text-primary transition-colors"
+            >
+              <Zap className="w-4 h-4" />
+            </Button>
+
+            {/* 快捷回复下拉面板 */}
+            {showQuickReplies && (
+              <div className="absolute bottom-full left-0 mb-2 w-80 max-h-60 overflow-y-auto bg-card border border-border rounded-lg shadow-lg z-50">
+                <div className="p-2 border-b border-border text-xs text-muted-foreground">
+                  快捷回复
+                </div>
+                <div className="p-1">
+                  {quickReplies.map((reply) => (
+                    <button
+                      key={reply.id}
+                      type="button"
+                      onClick={() => handleQuickReplySelect(reply)}
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-muted rounded-md transition-colors"
+                    >
+                      <div className="font-medium truncate">{reply.title}</div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {reply.content}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         <Input
           ref={inputRef}
           type="text"

--- a/frontend/features/agent/services/quickReplyApi.ts
+++ b/frontend/features/agent/services/quickReplyApi.ts
@@ -1,0 +1,159 @@
+import { API_BASE_URL } from "@/lib/config";
+
+export interface QuickReplySummary {
+  id: number;
+  user_id: number | null;
+  title: string;
+  content: string;
+  category: string;
+  sort_order: number;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateQuickReplyRequest {
+  user_id?: number | null;
+  title?: string;
+  content: string;
+  category?: string;
+  sort_order?: number;
+}
+
+export interface UpdateQuickReplyRequest {
+  title?: string;
+  content?: string;
+  category?: string;
+  sort_order?: number;
+  user_id?: number;
+}
+
+/**
+ * 获取快捷回复模板列表
+ */
+export async function fetchQuickReplies(
+  userId: number,
+  category?: string
+): Promise<QuickReplySummary[]> {
+  const params = new URLSearchParams();
+  params.set("user_id", String(userId));
+  if (category) {
+    params.set("category", category);
+  }
+
+  const res = await fetch(`${API_BASE_URL}/quick-replies?${params.toString()}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取快捷回复模板失败");
+  }
+
+  const data = await res.json();
+  return data.quick_replies || [];
+}
+
+/**
+ * 获取快捷回复模板详情
+ */
+export async function fetchQuickReply(id: number): Promise<QuickReplySummary> {
+  const res = await fetch(`${API_BASE_URL}/quick-replies/${id}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取快捷回复模板详情失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 创建快捷回复模板
+ */
+export async function createQuickReply(
+  request: CreateQuickReplyRequest
+): Promise<QuickReplySummary> {
+  const res = await fetch(`${API_BASE_URL}/quick-replies`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error || "创建快捷回复模板失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 更新快捷回复模板
+ */
+export async function updateQuickReply(
+  id: number,
+  request: UpdateQuickReplyRequest
+): Promise<QuickReplySummary> {
+  const res = await fetch(`${API_BASE_URL}/quick-replies/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error || "更新快捷回复模板失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 删除快捷回复模板
+ */
+export async function deleteQuickReply(id: number, userId?: number): Promise<void> {
+  const params = new URLSearchParams();
+  if (userId) {
+    params.set("user_id", String(userId));
+  }
+
+  const res = await fetch(`${API_BASE_URL}/quick-replies/${id}?${params.toString()}`, {
+    method: "DELETE",
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error || "删除快捷回复模板失败");
+  }
+}
+
+/**
+ * 记录快捷回复使用
+ */
+export async function recordQuickReplyUsage(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}/quick-replies/${id}/use`, {
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    // 不抛出错误，静默失败
+    console.error("记录使用次数失败");
+  }
+}
+
+/**
+ * 获取分类列表
+ */
+export async function fetchQuickReplyCategories(userId: number): Promise<string[]> {
+  const res = await fetch(`${API_BASE_URL}/quick-replies/categories?user_id=${userId}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取分类列表失败");
+  }
+
+  const data = await res.json();
+  return data.categories || [];
+}

--- a/frontend/features/agent/services/statisticsApi.ts
+++ b/frontend/features/agent/services/statisticsApi.ts
@@ -1,0 +1,120 @@
+import { API_BASE_URL } from "@/lib/config";
+
+export interface DashboardStats {
+  today_conversations: number;
+  today_messages: number;
+  online_agents: number;
+  active_visitors: number;
+  total_conversations: number;
+  total_messages: number;
+}
+
+export interface ConversationTrendData {
+  date: string;
+  count: number;
+  message_count: number;
+  visitor_count?: number;
+}
+
+export interface AgentWorkloadData {
+  agent_id: number;
+  agent_name: string;
+  conversation_count: number;
+  message_count: number;
+  avg_response_time: number;
+}
+
+export interface VisitorSourceData {
+  source: string;
+  count: number;
+}
+
+export interface AIStatsData {
+  total_ai_responses: number;
+  ai_response_rate: number;
+  avg_response_time: number;
+  human_takeover_rate: number;
+}
+
+/**
+ * 获取 Dashboard 概览统计数据
+ */
+export async function fetchDashboardStats(): Promise<DashboardStats> {
+  const res = await fetch(`${API_BASE_URL}/statistics/dashboard`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取统计数据失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 获取对话趋势数据
+ */
+export async function fetchConversationTrend(
+  days: number = 7
+): Promise<{ trend: ConversationTrendData[]; days: number }> {
+  const res = await fetch(`${API_BASE_URL}/statistics/conversations/trend?days=${days}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取对话趋势数据失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 获取客服工作量统计
+ */
+export async function fetchAgentWorkload(
+  days: number = 7
+): Promise<{ workload: AgentWorkloadData[]; days: number }> {
+  const res = await fetch(`${API_BASE_URL}/statistics/agents/workload?days=${days}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取客服工作量数据失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 获取访客分析数据
+ */
+export async function fetchVisitorAnalytics(days: number = 7): Promise<{
+  sources: VisitorSourceData[];
+  browsers: { browser: string; count: number }[];
+  hourly_dist: { hour: number; count: number }[];
+}> {
+  const res = await fetch(`${API_BASE_URL}/statistics/visitors?days=${days}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取访客分析数据失败");
+  }
+
+  return res.json();
+}
+
+/**
+ * 获取AI统计数据
+ */
+export async function fetchAIStats(days: number = 7): Promise<AIStatsData> {
+  const res = await fetch(`${API_BASE_URL}/statistics/ai?days=${days}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("获取AI统计数据失败");
+  }
+
+  return res.json();
+}

--- a/frontend/features/agent/types.ts
+++ b/frontend/features/agent/types.ts
@@ -92,3 +92,45 @@ export type ChatWebSocketPayload =
   | MessagesReadPayload
   | VisitorStatusUpdatePayload;
 
+// 快捷回复模板类型
+export interface QuickReplySummary {
+  id: number;
+  user_id: number | null;
+  title: string;
+  content: string;
+  category: string;
+  sort_order: number;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// 统计数据类型
+export interface DashboardStats {
+  today_conversations: number;
+  today_messages: number;
+  online_agents: number;
+  active_visitors: number;
+  total_conversations: number;
+  total_messages: number;
+}
+
+export interface ConversationTrendData {
+  date: string;
+  count: number;
+  message_count: number;
+}
+
+export interface AgentWorkloadData {
+  agent_id: number;
+  agent_name: string;
+  conversation_count: number;
+  message_count: number;
+  avg_response_time: number;
+}
+
+export interface VisitorSourceData {
+  source: string;
+  count: number;
+}
+

--- a/frontend/lib/constants/agent-pages.tsx
+++ b/frontend/lib/constants/agent-pages.tsx
@@ -10,6 +10,8 @@ import {
   ClipboardList,
   Users,
   Settings,
+  Zap,
+  BarChart3,
 } from "lucide-react";
 
 /** 嵌入在 dashboard 内的页面组件（懒加载） */
@@ -27,6 +29,14 @@ const UsersPage = dynamic(
 );
 const SettingsPage = dynamic(
   () => import("@/app/agent/settings/page").then((mod) => ({ default: mod.default })),
+  { ssr: false }
+);
+const QuickRepliesPage = dynamic(
+  () => import("@/app/agent/quick-replies/page").then((mod) => ({ default: mod.default })),
+  { ssr: false }
+);
+const StatisticsPage = dynamic(
+  () => import("@/app/agent/statistics/page").then((mod) => ({ default: mod.default })),
   { ssr: false }
 );
 
@@ -78,6 +88,22 @@ export const AGENT_PAGES = [
     Icon: ClipboardList,
     adminOnly: false,
     component: FAQsPage,
+  },
+  {
+    id: "quick-replies",
+    label: "快捷回复",
+    title: "快捷回复",
+    Icon: Zap,
+    adminOnly: false,
+    component: QuickRepliesPage,
+  },
+  {
+    id: "statistics",
+    label: "数据统计",
+    title: "数据统计",
+    Icon: BarChart3,
+    adminOnly: false,
+    component: StatisticsPage,
   },
   {
     id: "users",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "next": "16.1.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "recharts": "^3.8.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -79,6 +80,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2163,11 +2165,59 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmmirror.com/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmmirror.com/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2448,6 +2498,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2480,6 +2593,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2489,9 +2603,16 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -2535,6 +2656,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3015,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3346,6 +3469,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3534,6 +3658,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3607,6 +3852,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmmirror.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3882,6 +4133,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmmirror.com/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3908,6 +4169,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4086,6 +4348,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4324,6 +4587,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4770,6 +5039,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmmirror.com/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4807,6 +5086,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6182,6 +6470,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6190,6 +6479,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6201,7 +6491,31 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmmirror.com/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -6269,6 +6583,52 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmmirror.com/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6310,6 +6670,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -6880,6 +7246,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6918,6 +7290,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7057,6 +7430,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7226,6 +7600,37 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmmirror.com/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7361,6 +7766,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "next": "16.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "recharts": "^3.8.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- 在 `statisticsApi.ts` 中实现了新的 API 端点，用于获取仪表盘统计信息、对话趋势、客服工作量、访客分析和 AI 统计信息。

- 为统计 API 中使用的数据结构添加了相应的 TypeScript 接口。

- 更新了 `types.ts`，添加了仪表盘统计信息、对话趋势、客服工作量和访客来源的新类型。

- 在客服仪表盘中新增了快速回复和统计信息页面，并添加了相应的图标。

- 在统计信息页面中添加了 `recharts` 数据可视化库。